### PR TITLE
URI.escape is obsolete for ruby 2.7+

### DIFF
--- a/lib/kayako_client/http/net_http.rb
+++ b/lib/kayako_client/http/net_http.rb
@@ -13,6 +13,7 @@
 #######################################################################
 
 require 'net/https'
+require 'erb'
 
 module KayakoClient
     class NetHTTP
@@ -108,7 +109,7 @@ module KayakoClient
     private
 
         def urlencode(string)
-            URI.escape(string, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+           ERB::Util.url_encode(string)
         end
 
         def url(base, params = {})


### PR DESCRIPTION
https://www.rubydoc.info/stdlib/erb/ERB%2FUtil.url_encode

 ERB::Util.url_encode follows RFC 3986, which requires spaces to be encoded to %20